### PR TITLE
fix(file-specific styles): fix fallback color inconsistency.

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -146,8 +146,8 @@ rules = [
   { mime = "application/{pdf,doc,rtf,vnd.*}", fg = "#689d6a" },
 
   # Fallback
-  { name = "*", fg = "#ebdbb2" },
-  { name = "*/", fg = "#83a598" },
+  { url = "*", fg = "#ebdbb2" },
+  { url = "*/", fg = "#83a598" },
 ]
 
 # : }}}


### PR DESCRIPTION
In yazi v25.12.29, the `name` rule have been renamed to `url`, so the fallback section in file-specific styles needs to be updated.
